### PR TITLE
Implementation of a build flow extension point

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,11 @@
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.cloudbees.plugins</groupId>
+            <artifactId>build-flow-plugin</artifactId>
+            <version>0.9</version>
+        </dependency>
     </dependencies>
 
     <pluginRepositories>

--- a/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/extensions/BuildFlowPluginExtension.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/extensions/BuildFlowPluginExtension.java
@@ -1,0 +1,27 @@
+package com.sonyericsson.jenkins.plugins.externalresource.dispatcher.extensions;
+
+import hudson.Extension;
+
+import com.cloudbees.plugins.flow.BuildFlowDSLExtension;
+import com.cloudbees.plugins.flow.FlowDelegate;
+import com.sonyericsson.jenkins.plugins.externalresource.dispatcher.PluginImpl;
+
+/**
+ * Exposes the External Resource Manager to the Build Flow plugin
+ * See <a href="https://wiki.jenkins-ci.org/display/JENKINS/Build+Flow+Plugin">Build+Flow+Plugin</a>
+ *
+ * @author Patrik Johansson &lt;patrik.x.johansson@ericsson.com&gt;
+ *
+ */
+@Extension
+public class BuildFlowPluginExtension extends BuildFlowDSLExtension {
+
+  public Object createExtension(String extensionName, FlowDelegate dsl){
+    if(extensionName.equalsIgnoreCase("externalresource-dispatcher")){
+      return PluginImpl.getInstance().getManager();
+    }
+    else{
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
The new class BuildFlowPluginExtension exposes our external resource
manager to the build flow plugin so that it can be accessed from
within a build flow script like this:

  def manager = extension.'externalresource-dispatcher'
  manager.lock(...)

This allows us easy access to the manager without any imports
littering our build flow script

The code is a contribution from Ericsson AB (http://www.ericsson.com/) and has been reviewed internally by Marco Miller (https://github.com/marco-miller)
