### PR TITLE
Remove some object data from serialization

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/data/ExternalResource.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/data/ExternalResource.java
@@ -78,8 +78,8 @@ public class ExternalResource extends TreeNodeMetadataValue {
     private static final String NO_RESOURCE_MONITOR_EXCEPTION_MSG =
             "No resource monitor is currently active, this operation is not permitted.";
     private String id;
-    private StashInfo reserved;
-    private StashInfo locked;
+    private transient StashInfo reserved;
+    private transient StashInfo locked;
     /**
      * For access control purposes enabled can internally have 3 values; not set, true or false.
      * All logic related to enabled should handle "not set" as enabled.


### PR DESCRIPTION
Set the StashInfo fields of the ExternalResource object to transient. This disables the XML serialization per XStream into the main Jenkins configuration.
