### PR TITLE
Resource selection criteria can reference build parameters

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/ExternalResourceQueueTaskDispatcher.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/ExternalResourceQueueTaskDispatcher.java
@@ -101,7 +101,7 @@ public class ExternalResourceQueueTaskDispatcher extends QueueTaskDispatcher {
             return new BecauseNoAvailableResources(node);
         }
 
-        resources = selectionCriteria.getMatchingResources(resources);
+        resources = selectionCriteria.getMatchingResources(resources, item);
 
         if (resources == null || resources.isEmpty()) {
             //No matching resources, block the build on this node.

--- a/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/selection/AbstractResourceSelection.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/selection/AbstractResourceSelection.java
@@ -29,6 +29,7 @@ import hudson.model.Descriptor;
 
 import java.io.Serializable;
 
+import hudson.model.Queue;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import com.sonyericsson.jenkins.plugins.externalresource.dispatcher.data.ExternalResource;
@@ -55,4 +56,14 @@ public abstract class AbstractResourceSelection implements Serializable, Describ
      * @return true if resource selection equals to ExternalResource leaf value
      */
     public abstract boolean equalToExternalResourceValue(ExternalResource externalResource);
+    /**
+     * Resource selection input compare With ExternalResource leaf value.
+     * Takes a {@link hudson.model.Queue.Item} that can be queried for e.g. build parameter values.
+     *
+     * @param externalResource the External Resource
+     * @param qi Parent queue item
+     * @return true if resource selection equals to ExternalResource leaf value
+     */
+    public abstract boolean equalToExternalResourceValue(ExternalResource externalResource, Queue.Item qi);
+
 }


### PR DESCRIPTION
You can now reference build parameters as variables in resource selection criteria:

![screen shot 2014-12-10 at 6 40 34 pm](https://cloud.githubusercontent.com/assets/163239/5388234/1cfd18ac-809c-11e4-99ab-9b862c64f3ac.png)

I apologize if there was a better way to implement this, this is my first time submitting a patch to Jenkins. Let me know if there is a better approach and I'll gladly update my PR.

Thanks!
