### PR TITLE
[JENKINS-43497] Make Build Flow Plugin an optional dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 target
 work
 bin
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -89,15 +89,21 @@
         </dependency>
         <!-- add dependency for the json rpc -->
         <dependency>
-            <groupId>com.googlecode</groupId>
+            <groupId>com.github.briandilley.jsonrpc4j</groupId>
             <artifactId>jsonrpc4j</artifactId>
-            <version>0.18</version>
+            <version>1.5.0</version>
         </dependency>
         <!-- Apache license Jackson: -->
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
             <version>1.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.5</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
             <groupId>com.cloudbees.plugins</groupId>
             <artifactId>build-flow-plugin</artifactId>
             <version>0.9</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/extensions/BuildFlowPluginExtension.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/extensions/BuildFlowPluginExtension.java
@@ -13,7 +13,7 @@ import com.sonyericsson.jenkins.plugins.externalresource.dispatcher.PluginImpl;
  * @author Patrik Johansson &lt;patrik.x.johansson@ericsson.com&gt;
  *
  */
-@Extension
+@Extension(optional = true)
 public class BuildFlowPluginExtension extends BuildFlowDSLExtension {
 
   public Object createExtension(String extensionName, FlowDelegate dsl){

--- a/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/extensions/BuildFlowPluginExtension.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/extensions/BuildFlowPluginExtension.java
@@ -7,21 +7,20 @@ import com.cloudbees.plugins.flow.FlowDelegate;
 import com.sonyericsson.jenkins.plugins.externalresource.dispatcher.PluginImpl;
 
 /**
- * Exposes the External Resource Manager to the Build Flow plugin
+ * Exposes the External Resource Manager to the Build Flow plugin.
  * See <a href="https://wiki.jenkins-ci.org/display/JENKINS/Build+Flow+Plugin">Build+Flow+Plugin</a>
  *
  * @author Patrik Johansson &lt;patrik.x.johansson@ericsson.com&gt;
- *
  */
 @Extension(optional = true)
 public class BuildFlowPluginExtension extends BuildFlowDSLExtension {
 
-  public Object createExtension(String extensionName, FlowDelegate dsl){
-    if(extensionName.equalsIgnoreCase("externalresource-dispatcher")){
-      return PluginImpl.getInstance().getManager();
+    @Override
+    public Object createExtension(String extensionName, FlowDelegate dsl) {
+        if (extensionName.equalsIgnoreCase("externalresource-dispatcher")) {
+            return PluginImpl.getInstance().getManager();
+        } else {
+            return null;
+        }
     }
-    else{
-      return null;
-    }
-  }
 }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/utils/JsonRpcUtil.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/utils/JsonRpcUtil.java
@@ -111,7 +111,7 @@ public final class JsonRpcUtil {
             @SuppressWarnings("unchecked")
             public JsonNode valueToTree(Object params) {
                 if (params.getClass().isArray()) {
-                    Object[] paramArray = (Object[]) params;
+                    Object[] paramArray = (Object[])params;
                     if (paramArray.length == 1) { // if only one element  there.
                         return super.valueToTree(paramArray[0]);
                     }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/utils/JsonRpcUtil.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/utils/JsonRpcUtil.java
@@ -30,15 +30,16 @@ import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * this is the util class for json rpc.
  * you can create different rpc client for use.
- * @author Leimeng Zhang
  *
+ * @author Leimeng Zhang
  */
 public final class JsonRpcUtil {
 
@@ -55,6 +56,7 @@ public final class JsonRpcUtil {
 
     /**
      * create the Json RPC client using the specified url.
+     *
      * @param url the url of the RPC call.
      * @return the {@link JsonRpcHttpClient} to be used.
      */
@@ -72,7 +74,8 @@ public final class JsonRpcUtil {
 
     /**
      * create the Json RPC client using the specified url and a customized {@link ObjectMapper}.
-     * @param url the url of the RPC call.
+     *
+     * @param url                    the url of the RPC call.
      * @param customizedObjectMapper the customized {@link ObjectMapper} to support rpc json format.
      * @return the {@link JsonRpcHttpClient} to be used.
      */
@@ -87,6 +90,7 @@ public final class JsonRpcUtil {
         }
         return client;
     }
+
     /**
      * create the customized object mapper, which is used to read/write json
      * object. by doing so, the object[] will cast to be one jsonObject if
@@ -107,7 +111,7 @@ public final class JsonRpcUtil {
             @SuppressWarnings("unchecked")
             public JsonNode valueToTree(Object params) {
                 if (params.getClass().isArray()) {
-                    Object[] paramArray = (Object[])params;
+                    Object[] paramArray = (Object[]) params;
                     if (paramArray.length == 1) { // if only one element  there.
                         return super.valueToTree(paramArray[0]);
                     }

--- a/src/test/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/utils/resourcemanagers/ExternalResourceManagerTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/externalresource/dispatcher/utils/resourcemanagers/ExternalResourceManagerTest.java
@@ -46,7 +46,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import net.sf.json.JSONObject;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;


### PR DESCRIPTION
[JENKINS-43497](https://issues.jenkins-ci.org/browse/JENKINS-43497)

I couldn't build with the existing json rpc dependency because it wasn't available in maven central, so the first commit is to switch to a newer lib that can be reverted if needed. Not tested if it works in a real installation or not except for if there are any unit tests for it.